### PR TITLE
Resolve issue hardening suite: signal policy, state revision, KDJ alerts, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm run check
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@
 - 成本价与盈亏：支持 4 位小数成本价，自动计算盈亏比例
 - 闭市暂停：交易时段外自动停止拉取，开市后自动恢复
 - 预警引擎：
-  - 规则类型：价格阈值、单日涨跌幅、MA 突破、MACD 金叉死叉、RSI 超买超卖
+  - 规则类型：价格阈值、单日涨跌幅、MA 突破、MACD 金叉死叉、RSI 超买超卖、KDJ 金叉死叉/区间
   - 触发机制：基于实时刷新结果和技术指标变化检测，支持规则冷却时间去重
   - 通知方式：工作通知流（静默）、可选声音/震动、低功耗监控模式
   - 管理能力：规则列表、历史记录、触发统计、一键启用/禁用
 - 持久化：
   - 浏览器 `localStorage` 兜底
   - 服务端 `.dashboard-state.json` 持久化
+  - `revision` 冲突检测，避免多标签页互相覆盖状态
 - 历史分析与策略回测：
   - 策略类型：MA 交叉、MACD、RSI、价格突破、组合策略
   - 参数维度：周期（日/周/月）、仓位、止损止盈、手续费、滑点、持仓周期
@@ -72,8 +73,18 @@ http://127.0.0.1:8000
 - 前端会在变更时同步写入：
   - `localStorage`（键：`stock_dashboard_cards_v1`）
   - `localStorage`（键：`stock_dashboard_alert_engine_v1`）
-  - `POST /api/state`（落盘到 `.dashboard-state.json`，包含 cards + alerts）
+  - `POST /api/state`（落盘到 `.dashboard-state.json`，包含 cards + alerts + revision）
 - 页面加载时优先读取 `GET /api/state`，远端为空时回退到本地数据。
+- 发生并发写入冲突时，服务端返回 `409` 与最新快照，前端会自动合并并重试。
+
+## 开发验证
+
+```bash
+npm run check
+npm test
+```
+
+项目使用 Node 原生测试与 GitHub Actions CI（PR 自动执行语法检查与测试）。
 
 ## 当前限制
 

--- a/analysis.html
+++ b/analysis.html
@@ -167,6 +167,9 @@
       </section>
     </main>
 
+    <script src="./core/shared-utils.js"></script>
+    <script src="./core/indicator-utils.js"></script>
+    <script src="./core/signal-policy.js"></script>
     <script src="./analysis.js"></script>
   </body>
 </html>

--- a/analysis.js
+++ b/analysis.js
@@ -2,6 +2,9 @@ const ANALYSIS_HISTORY_DAYS = 260;
 const ANALYSIS_SEARCH_LIMIT = 10;
 const PLAYBACK_INTERVAL_MS = 720;
 const STRATEGY_STORAGE_KEY = "analysis_strategy_config_v1";
+const coreUtils = window.DashboardCore || {};
+const indicatorUtils = window.DashboardIndicatorCore || {};
+const signalPolicyUtils = window.DashboardSignalPolicyCore || {};
 const PRESET_BAR_COUNTS = {
   "3m": 60,
   "6m": 120,
@@ -103,6 +106,7 @@ const EXECUTION_CONFIG_FIELDS = [
   { key: "takeProfitPct", label: "止盈阈值(%)", type: "number", min: 0, max: 200, step: 0.5 },
   { key: "feeBps", label: "手续费(bp)", type: "number", min: 0, max: 100, step: 0.5 },
   { key: "slippageBps", label: "滑点(bp)", type: "number", min: 0, max: 100, step: 0.5 },
+  { key: "noSameBarReentry", label: "禁止同周期卖出后立即买回", type: "checkbox" },
 ];
 
 const ANNUALIZATION_FACTOR = {
@@ -892,9 +896,13 @@ function renderChart() {
   const currentX = mapX(analysisState.currentIndex).toFixed(2);
   const currentY = mapY(current.close).toFixed(2);
 
+  const signalMarkerOrder = new Map();
   const signalMarkers = analysisState.signals
     .map((signal) => {
-      const x = mapX(signal.index);
+      const key = `${signal.index}:${signal.type}`;
+      const sameSlotCount = signalMarkerOrder.get(key) || 0;
+      signalMarkerOrder.set(key, sameSlotCount + 1);
+      const x = mapX(signal.index) + sameSlotCount * 6 - 3;
       const y = mapY(signal.price);
       const points =
         signal.type === "buy"
@@ -905,7 +913,9 @@ function renderChart() {
               2
             )},${(y - 4).toFixed(2)}`;
       return `<polygon class="analysis-signal-marker ${signal.type === "buy" ? "is-buy" : "is-sell"}" points="${points}">
-        <title>${escapeHtml(signal.label)} · ${escapeHtml(signal.date)} · ${escapeHtml(signal.reason)}</title>
+        <title>${escapeHtml(signal.label)} · ${escapeHtml(signal.sourceIndicator || "Strategy")} · ${escapeHtml(
+          signal.date
+        )} · ${escapeHtml(signal.reason)}</title>
       </polygon>`;
     })
     .join("");
@@ -985,15 +995,29 @@ function renderSnapshot() {
     return;
   }
 
-  const signal = analysisState.signals.find((item) => item.index === analysisState.currentIndex) || null;
+  const currentSignals = analysisState.signals.filter((item) => item.index === analysisState.currentIndex);
+  const signalBadges = currentSignals
+    .map((signal) => {
+      const tone = signal.type === "buy" ? "is-positive" : "is-negative";
+      const source = signal.sourceIndicator ? `(${signal.sourceIndicator})` : "";
+      return buildAnalysisBadge(`${signal.label}${source}`, tone);
+    })
+    .join("");
   const tags = [
     buildAnalysisBadge(indicator.bias, toneForBias(indicator.bias)),
     buildAnalysisBadge(indicator.macdSignal, toneForMacd(indicator.macdSignal)),
     buildAnalysisBadge(indicator.rsiSignal, toneForRsi(indicator.rsiSignal)),
-    signal ? buildAnalysisBadge(signal.label, signal.type === "buy" ? "is-positive" : "is-negative") : "",
+    signalBadges,
   ]
     .filter(Boolean)
     .join("");
+
+  const signalHints = currentSignals.length
+    ? currentSignals.map((signal) => {
+        const source = signal.sourceIndicator ? `[${signal.sourceIndicator}] ` : "";
+        return `${source}${signal.reason}`;
+      })
+    : [];
 
   analysisRefs.snapshot.className = "analysis-snapshot";
   analysisRefs.snapshot.innerHTML = `<div class="analysis-snapshot-head">
@@ -1017,7 +1041,9 @@ function renderSnapshot() {
     ${analysisMetricTile("当日高低", `${formatNumber(current.high)} / ${formatNumber(current.low)}`)}
     ${analysisMetricTile("成交量", formatCompact(current.volume))}
   </div>
-  <p class="analysis-snapshot-note">${escapeHtml(signal?.reason || "当前时点无新增策略信号。")}</p>`;
+  <p class="analysis-snapshot-note">${escapeHtml(
+    signalHints.length ? signalHints.join("；") : "当前时点无新增策略信号。"
+  )}</p>`;
 }
 
 function renderBacktest() {
@@ -1078,7 +1104,9 @@ function renderBacktest() {
   <div class="analysis-snapshot-grid">${summary}</div>
   <p class="analysis-snapshot-note">${escapeHtml(
     stats.lastSignal
-      ? `最新信号：${stats.lastSignal.date} ${stats.lastSignal.label}，${stats.lastSignal.reason}`
+      ? `最新信号：${stats.lastSignal.date} ${stats.lastSignal.label}${
+          stats.lastSignal.sourceIndicator ? `(${stats.lastSignal.sourceIndicator})` : ""
+        }，${stats.lastSignal.reason}`
       : "当前区间未触发明确策略信号。"
   )}</p>
   <p class="analysis-snapshot-note">${escapeHtml(
@@ -1338,6 +1366,7 @@ async function runBacktest(bars, indicators, strategyConfigInput, onProgress) {
     if (position) inMarketBars += 1;
 
     let plannedExit = null;
+    let hadExitOnCurrentBar = false;
     if (position && Number.isFinite(position.entryRawPrice) && position.entryRawPrice > 0) {
       const grossReturnPct = ((point.close - position.entryRawPrice) / position.entryRawPrice) * 100;
       if (execution.stopLossPct > 0 && grossReturnPct <= -execution.stopLossPct) {
@@ -1396,11 +1425,28 @@ async function runBacktest(bars, indicators, strategyConfigInput, onProgress) {
         price: point.close,
         label: "卖出",
         reason: plannedExit.reason,
+        reasonCode: plannedExit.code,
+        sourceIndicator:
+          typeof signalPolicyUtils.signalSourceForStrategy === "function"
+            ? signalPolicyUtils.signalSourceForStrategy(strategyConfig.type, "sell", plannedExit.code)
+            : plannedExit.code === "signal"
+              ? "Strategy"
+              : "Risk",
       });
       position = null;
+      hadExitOnCurrentBar = true;
     }
 
-    if (!position && positionSize > 0 && shouldEnterStrategy(strategyConfig.type, previous, point, strategyConfig.params)) {
+    const allowSameBarEntry =
+      typeof signalPolicyUtils.shouldAllowSameBarEntry === "function"
+        ? signalPolicyUtils.shouldAllowSameBarEntry(execution, hadExitOnCurrentBar)
+        : !hadExitOnCurrentBar;
+    if (
+      !position &&
+      allowSameBarEntry &&
+      positionSize > 0 &&
+      shouldEnterStrategy(strategyConfig.type, previous, point, strategyConfig.params)
+    ) {
       const entryCapital = cash * positionSize;
       if (entryCapital > 0 && Number.isFinite(point.close) && point.close > 0) {
         const execPrice = point.close * (1 + slippageRate);
@@ -1425,6 +1471,11 @@ async function runBacktest(bars, indicators, strategyConfigInput, onProgress) {
             price: point.close,
             label: "买入",
             reason: buildStrategyEntryReason(strategyConfig.type, previous, point, strategyConfig.params),
+            reasonCode: "signal",
+            sourceIndicator:
+              typeof signalPolicyUtils.signalSourceForStrategy === "function"
+                ? signalPolicyUtils.signalSourceForStrategy(strategyConfig.type, "buy", "signal")
+                : "Strategy",
           });
         }
       }
@@ -1846,6 +1897,7 @@ function getDefaultExecutionConfig() {
     takeProfitPct: 18,
     feeBps: 6,
     slippageBps: 4,
+    noSameBarReentry: true,
   };
 }
 
@@ -1863,6 +1915,7 @@ function sanitizeExecutionConfig(rawInput) {
     takeProfitPct: clampNumber(raw.takeProfitPct, 0, 200, defaults.takeProfitPct),
     feeBps: clampNumber(raw.feeBps, 0, 100, defaults.feeBps),
     slippageBps: clampNumber(raw.slippageBps, 0, 100, defaults.slippageBps),
+    noSameBarReentry: raw.noSameBarReentry !== false,
   };
 }
 
@@ -1880,7 +1933,11 @@ function describeStrategyConfig(configInput) {
     execution.positionSizePct,
     0,
     0
-  )}% · 止损/止盈 ${formatNumber(execution.stopLossPct, 1, 1)}%/${formatNumber(execution.takeProfitPct, 1, 1)}%`;
+  )}% · 止损/止盈 ${formatNumber(execution.stopLossPct, 1, 1)}%/${formatNumber(
+    execution.takeProfitPct,
+    1,
+    1
+  )}% · ${execution.noSameBarReentry ? "禁同周期反手" : "允许同周期反手"}`;
 
   if (config.type === "ma_cross") {
     return `MA${params.fastPeriod} 上穿 MA${params.slowPeriod} 买入，下穿卖出 · ${executionSummary}`;
@@ -2034,17 +2091,17 @@ function downloadCsv(filename, content) {
 }
 
 function calculateSmaAt(values, index, period) {
-  if (index + 1 < period) return null;
-  const window = values.slice(index + 1 - period, index + 1);
-  const sum = window.reduce((acc, value) => acc + value, 0);
-  return sum / period;
+  if (typeof indicatorUtils.calculateSmaAt === "function") {
+    return indicatorUtils.calculateSmaAt(values, index, period);
+  }
+  return null;
 }
 
 function calculateSmaSeries(values, period) {
-  if (!Array.isArray(values) || !values.length || !Number.isFinite(period) || period < 1) {
-    return [];
+  if (typeof indicatorUtils.calculateSmaSeries === "function") {
+    return indicatorUtils.calculateSmaSeries(values, period);
   }
-  return values.map((_, index) => calculateSmaAt(values, index, period));
+  return [];
 }
 
 function calculateRollingExtremeSeries(values, period, mode, lookbackOffset = 1) {
@@ -2148,54 +2205,17 @@ function yieldToUi() {
 }
 
 function calculateEmaSeries(values, period) {
-  if (!Array.isArray(values) || !values.length) return [];
-  const multiplier = 2 / (period + 1);
-  let previous = Number(values[0]);
-  return values.map((value, index) => {
-    const current = Number(value);
-    if (!Number.isFinite(current)) return previous;
-    if (index === 0 || !Number.isFinite(previous)) {
-      previous = current;
-      return current;
-    }
-    previous = current * multiplier + previous * (1 - multiplier);
-    return previous;
-  });
+  if (typeof indicatorUtils.calculateEmaSeries === "function") {
+    return indicatorUtils.calculateEmaSeries(values, period);
+  }
+  return [];
 }
 
 function calculateRsiSeries(values, period) {
-  if (!Array.isArray(values) || !values.length) return [];
-
-  const series = new Array(values.length).fill(null);
-  if (values.length <= period) {
-    return series;
+  if (typeof indicatorUtils.calculateRsiSeries === "function") {
+    return indicatorUtils.calculateRsiSeries(values, period);
   }
-
-  let gains = 0;
-  let losses = 0;
-  for (let index = 1; index <= period; index += 1) {
-    const delta = values[index] - values[index - 1];
-    if (delta >= 0) {
-      gains += delta;
-    } else {
-      losses -= delta;
-    }
-  }
-
-  let avgGain = gains / period;
-  let avgLoss = losses / period;
-  series[period] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
-
-  for (let index = period + 1; index < values.length; index += 1) {
-    const delta = values[index] - values[index - 1];
-    const gain = delta > 0 ? delta : 0;
-    const loss = delta < 0 ? -delta : 0;
-    avgGain = (avgGain * (period - 1) + gain) / period;
-    avgLoss = (avgLoss * (period - 1) + loss) / period;
-    series[index] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
-  }
-
-  return series;
+  return [];
 }
 
 function normalizeHistoricalBar(item) {
@@ -2300,33 +2320,18 @@ function setAnalysisStatus(text) {
 }
 
 function numberOrNull(value) {
+  if (typeof coreUtils.numberOrNull === "function") {
+    return coreUtils.numberOrNull(value);
+  }
   const num = Number(value);
   return Number.isFinite(num) ? num : null;
 }
 
 function toYahooSymbol(input) {
-  const raw = String(input || "").trim().toUpperCase();
-  if (/^\d{6}\.(SH|SS|SZ)$/.test(raw)) {
-    const [code, suffix] = raw.split(".");
-    return `${code}.${suffix === "SH" ? "SS" : suffix}`;
+  if (typeof coreUtils.toYahooSymbol === "function") {
+    return coreUtils.toYahooSymbol(input);
   }
-  if (/^(SH|SZ)\d{6}$/.test(raw)) {
-    return `${raw.slice(2)}.${raw.startsWith("SH") ? "SS" : "SZ"}`;
-  }
-  if (/^\d{6}$/.test(raw)) {
-    return `${raw}.${raw.startsWith("6") ? "SS" : "SZ"}`;
-  }
-  if (/^HK\d{4,5}$/.test(raw)) {
-    return `${raw.slice(2).padStart(4, "0")}.HK`;
-  }
-  if (/^\d{4,5}\.HK$/.test(raw)) {
-    const [code] = raw.split(".");
-    return `${code.padStart(4, "0")}.HK`;
-  }
-  if (/^\d{4,5}$/.test(raw)) {
-    return `${raw.padStart(4, "0")}.HK`;
-  }
-  return raw;
+  return String(input || "").trim().toUpperCase();
 }
 
 function normalizeErrorMessage(error) {
@@ -2341,6 +2346,9 @@ function isHttpOrigin() {
 }
 
 function formatNumber(value, minDigits = 2, maxDigits = 2) {
+  if (typeof coreUtils.formatNumber === "function") {
+    return coreUtils.formatNumber(value, minDigits, maxDigits);
+  }
   if (value == null || Number.isNaN(value)) return "--";
   return Number(value).toLocaleString(undefined, {
     minimumFractionDigits: minDigits,
@@ -2349,26 +2357,25 @@ function formatNumber(value, minDigits = 2, maxDigits = 2) {
 }
 
 function formatSigned(value) {
+  if (typeof coreUtils.formatSigned === "function") {
+    return coreUtils.formatSigned(value);
+  }
   if (value == null || Number.isNaN(value)) return "--";
-  const abs = Math.abs(value);
-  const fixed = abs.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-  return `${value >= 0 ? "+" : "-"}${fixed}`;
+  return `${value >= 0 ? "+" : "-"}${Math.abs(value).toFixed(2)}`;
 }
 
 function formatSignedFixed(value, digits = 2) {
+  if (typeof coreUtils.formatSignedFixed === "function") {
+    return coreUtils.formatSignedFixed(value, digits);
+  }
   if (value == null || Number.isNaN(value)) return "--";
-  const abs = Math.abs(value);
-  const fixed = abs.toLocaleString(undefined, {
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits,
-  });
-  return `${value >= 0 ? "+" : "-"}${fixed}`;
+  return `${value >= 0 ? "+" : "-"}${Math.abs(value).toFixed(digits)}`;
 }
 
 function formatCompact(value) {
+  if (typeof coreUtils.formatCompact === "function") {
+    return coreUtils.formatCompact(value);
+  }
   if (value == null || Number.isNaN(value)) return "--";
   return Number(value).toLocaleString(undefined, {
     notation: "compact",
@@ -2377,21 +2384,15 @@ function formatCompact(value) {
 }
 
 function escapeHtml(value) {
-  return String(value ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+  if (typeof coreUtils.escapeHtml === "function") {
+    return coreUtils.escapeHtml(value);
+  }
+  return String(value ?? "");
 }
 
 function debounce(fn, waitMs) {
-  let timer = null;
-  return (...args) => {
-    if (timer) window.clearTimeout(timer);
-    timer = window.setTimeout(() => {
-      timer = null;
-      fn(...args);
-    }, waitMs);
-  };
+  if (typeof coreUtils.debounce === "function") {
+    return coreUtils.debounce(fn, waitMs);
+  }
+  return fn;
 }

--- a/app.js
+++ b/app.js
@@ -12,13 +12,16 @@ const QUOTE_DEFAULT_TOPIC = "mixed";
 const QUOTE_TOPICS = new Set(["mixed", "economics", "philosophy", "engineering"]);
 const DEFAULT_CARD_VISUAL_SIZE = "standard";
 const CARD_VISUAL_SIZES = new Set(["compact", "standard", "expanded"]);
+const coreUtils = window.DashboardCore || {};
+const indicatorUtils = window.DashboardIndicatorCore || {};
+const stateMergeUtils = window.DashboardStateMergeCore || {};
 const LONG_PRESS_MS = 380;
 const LONG_PRESS_MOVE_TOLERANCE = 10;
 const ALERT_HISTORY_LIMIT = 180;
 const ALERT_SCAN_COOLDOWN_MS = 0;
 const ALERT_LOW_POWER_SCAN_COOLDOWN_MS = 30000;
 const ALERT_DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
-const ALERT_RULE_TYPES = new Set(["price", "change", "ma_breakout", "macd_cross", "rsi_zone"]);
+const ALERT_RULE_TYPES = new Set(["price", "change", "ma_breakout", "macd_cross", "rsi_zone", "kdj_cross", "kdj_zone"]);
 const ALERT_MA_KEYS = new Set(["ma5", "ma10", "ma20"]);
 const ALERT_RULE_TYPE_LABELS = {
   price: "价格阈值",
@@ -26,6 +29,8 @@ const ALERT_RULE_TYPE_LABELS = {
   ma_breakout: "MA 突破",
   macd_cross: "MACD 信号",
   rsi_zone: "RSI 区间",
+  kdj_cross: "KDJ 信号",
+  kdj_zone: "KDJ 区间",
 };
 const ALERT_COOLDOWN_OPTIONS = [
   { value: 60 * 1000, label: "1 分钟" },
@@ -198,6 +203,8 @@ const state = {
   cards: [],
   refreshTimer: null,
   remoteSaveTimer: null,
+  remoteRevision: 0,
+  remoteSaveInFlight: false,
   stockSuggestions: [],
   isReordering: false,
   alertEngine: buildDefaultAlertEngineState(),
@@ -1174,6 +1181,7 @@ async function loadCards() {
   if (isHttpOrigin()) {
     remoteState = await readRemoteState();
   }
+  state.remoteRevision = Number(remoteState?.revision) || 0;
 
   const remoteCards = Array.isArray(remoteState?.cards) ? remoteState.cards : null;
 
@@ -1201,8 +1209,7 @@ async function loadCards() {
       state.alertEngine.history.length > 0 ||
       state.alertEngine.totalTriggered > 0)
   ) {
-    const snapshot = JSON.stringify({ cards: serializeCards(), alerts: serializeAlertEngine() });
-    void persistRemoteState(snapshot);
+    void persistRemoteState({ cards: serializeCards(), alerts: serializeAlertEngine() });
   }
 }
 
@@ -1368,6 +1375,7 @@ async function readRemoteState() {
     return {
       cards: Array.isArray(payload?.cards) ? payload.cards : [],
       alerts: payload?.alerts && typeof payload.alerts === "object" ? payload.alerts : null,
+      revision: Number.isFinite(Number(payload?.revision)) ? Number(payload.revision) : 0,
     };
   } catch {
     return null;
@@ -1378,25 +1386,86 @@ function scheduleRemoteSave(cardsPayload = serializeCards(), alertsPayload = ser
   if (!isHttpOrigin()) return;
   if (state.remoteSaveTimer) clearTimeout(state.remoteSaveTimer);
 
-  const snapshot = JSON.stringify({ cards: cardsPayload, alerts: alertsPayload });
+  const snapshot = { cards: cardsPayload, alerts: alertsPayload };
   state.remoteSaveTimer = setTimeout(() => {
     void persistRemoteState(snapshot);
   }, REMOTE_SAVE_DEBOUNCE_MS);
 }
 
-async function persistRemoteState(snapshot) {
+async function persistRemoteState(snapshot, attempt = 0) {
+  if (!snapshot || typeof snapshot !== "object") return;
+
+  state.remoteSaveInFlight = true;
   try {
-    await fetch(STATE_ENDPOINT, {
+    const response = await fetch(STATE_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: snapshot,
+      body: JSON.stringify({
+        cards: Array.isArray(snapshot.cards) ? snapshot.cards : [],
+        alerts: snapshot.alerts && typeof snapshot.alerts === "object" ? snapshot.alerts : buildDefaultAlertEngineState(),
+        revision: state.remoteRevision || 0,
+      }),
       cache: "no-store",
     });
+
+    if (response.status === 409) {
+      const payload = await response.json().catch(() => null);
+      const remoteState = {
+        cards: Array.isArray(payload?.cards) ? payload.cards : [],
+        alerts: payload?.alerts && typeof payload.alerts === "object" ? payload.alerts : buildDefaultAlertEngineState(),
+        revision: Number.isFinite(Number(payload?.revision)) ? Number(payload.revision) : 0,
+      };
+      state.remoteRevision = remoteState.revision;
+
+      const merged = mergeDashboardStateForConflict(snapshot, remoteState);
+      state.cards = hydrateCards(merged.cards);
+      state.alertEngine = hydrateAlertEngine(merged.alerts, state.cards);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(serializeCards()));
+      localStorage.setItem(ALERT_STORAGE_KEY, JSON.stringify(serializeAlertEngine()));
+      render();
+      renderAlertWorkbench();
+
+      if (attempt < 1) {
+        await persistRemoteState({ cards: merged.cards, alerts: merged.alerts }, attempt + 1);
+      }
+      return;
+    }
+
+    if (!response.ok) return;
+    const payload = await response.json().catch(() => null);
+    if (Number.isFinite(Number(payload?.revision))) {
+      state.remoteRevision = Number(payload.revision);
+    } else {
+      state.remoteRevision += 1;
+    }
   } catch {
     // Keep localStorage as durable fallback.
+  } finally {
+    state.remoteSaveInFlight = false;
   }
+}
+
+function mergeDashboardStateForConflict(localSnapshot, remoteState) {
+  if (typeof stateMergeUtils.mergeDashboardState === "function") {
+    return stateMergeUtils.mergeDashboardState(
+      {
+        cards: Array.isArray(localSnapshot.cards) ? localSnapshot.cards : [],
+        alerts:
+          localSnapshot.alerts && typeof localSnapshot.alerts === "object"
+            ? localSnapshot.alerts
+            : buildDefaultAlertEngineState(),
+      },
+      remoteState,
+      { alertHistoryLimit: ALERT_HISTORY_LIMIT }
+    );
+  }
+
+  return {
+    cards: Array.isArray(remoteState.cards) ? remoteState.cards : [],
+    alerts: remoteState.alerts && typeof remoteState.alerts === "object" ? remoteState.alerts : buildDefaultAlertEngineState(),
+  };
 }
 
 function render() {
@@ -1583,12 +1652,36 @@ function renderAlertRuleParams(type, params, disabled = false) {
     return;
   }
 
-  refs.alertRuleParams.innerHTML = `<label class="alert-inline-field">
+  if (type === "rsi_zone") {
+    refs.alertRuleParams.innerHTML = `<label class="alert-inline-field">
       <span>区间</span>
       <select data-alert-param="zone">
         <option value="both" ${normalized.zone === "both" ? "selected" : ""}>超买或超卖</option>
         <option value="overbought" ${normalized.zone === "overbought" ? "selected" : ""}>超买 (RSI ≥ 70)</option>
         <option value="oversold" ${normalized.zone === "oversold" ? "selected" : ""}>超卖 (RSI ≤ 30)</option>
+      </select>
+    </label>`;
+    return;
+  }
+
+  if (type === "kdj_cross") {
+    refs.alertRuleParams.innerHTML = `<label class="alert-inline-field">
+      <span>信号</span>
+      <select data-alert-param="signal">
+        <option value="both" ${normalized.signal === "both" ? "selected" : ""}>金叉或死叉</option>
+        <option value="golden" ${normalized.signal === "golden" ? "selected" : ""}>金叉</option>
+        <option value="death" ${normalized.signal === "death" ? "selected" : ""}>死叉</option>
+      </select>
+    </label>`;
+    return;
+  }
+
+  refs.alertRuleParams.innerHTML = `<label class="alert-inline-field">
+      <span>区间</span>
+      <select data-alert-param="zone">
+        <option value="both" ${normalized.zone === "both" ? "selected" : ""}>超买或超卖</option>
+        <option value="overbought" ${normalized.zone === "overbought" ? "selected" : ""}>超买 (KDJ J ≥ 100)</option>
+        <option value="oversold" ${normalized.zone === "oversold" ? "selected" : ""}>超卖 (KDJ J ≤ 0)</option>
       </select>
     </label>`;
 }
@@ -1598,7 +1691,7 @@ function renderAlertRuleList() {
   const rules = state.alertEngine.rules || [];
   if (!rules.length) {
     refs.alertRuleList.innerHTML =
-      '<p class="status-text">暂无预警规则。可以先添加价格阈值或 MA/MACD/RSI 规则。</p>';
+      '<p class="status-text">暂无预警规则。可以先添加价格阈值或 MA/MACD/RSI/KDJ 规则。</p>';
     return;
   }
 
@@ -1641,7 +1734,9 @@ function renderAlertHistoryList() {
     .map(
       (item) => `<article class="alert-history-item">
         <div>
-          <p class="alert-history-title">${escapeHtml(item.title || "工作通知")}</p>
+          <p class="alert-history-title">${escapeHtml(item.title || "工作通知")}${
+            item.sourceIndicator ? ` · ${escapeHtml(item.sourceIndicator)}` : ""
+          }</p>
           <p class="alert-history-detail">${escapeHtml(item.detail || "--")}</p>
         </div>
         <p class="alert-history-time">${escapeHtml(formatRelativeTime(item.triggeredAt))}</p>
@@ -1706,6 +1801,16 @@ function collectAlertRuleParams(type) {
     return normalizeAlertRuleParams(type, { signal });
   }
 
+  if (type === "rsi_zone") {
+    const zone = String(root.querySelector('[data-alert-param="zone"]')?.value || "both");
+    return normalizeAlertRuleParams(type, { zone });
+  }
+
+  if (type === "kdj_cross") {
+    const signal = String(root.querySelector('[data-alert-param="signal"]')?.value || "both");
+    return normalizeAlertRuleParams(type, { signal });
+  }
+
   const zone = String(root.querySelector('[data-alert-param="zone"]')?.value || "both");
   return normalizeAlertRuleParams(type, { zone });
 }
@@ -1762,6 +1867,11 @@ function normalizeAlertRuleParams(type, rawParams) {
     return { signal };
   }
 
+  if (type === "kdj_cross") {
+    const signal = ["golden", "death", "both"].includes(params.signal) ? params.signal : "both";
+    return { signal };
+  }
+
   const zone = ["overbought", "oversold", "both"].includes(params.zone) ? params.zone : "both";
   return { zone };
 }
@@ -1780,6 +1890,7 @@ function normalizeAlertHistoryRecord(record) {
   const title = String(record.title || "");
   const detail = String(record.detail || "");
   const type = ALERT_RULE_TYPES.has(record.type) ? record.type : "price";
+  const sourceIndicator = String(record.sourceIndicator || "");
   const symbol = String(record.symbol || "");
   const triggeredAt = Number.isFinite(Number(record.triggeredAt)) ? Number(record.triggeredAt) : Date.now();
   return {
@@ -1787,6 +1898,7 @@ function normalizeAlertHistoryRecord(record) {
     ruleId,
     cardId,
     type,
+    sourceIndicator,
     symbol,
     title,
     detail,
@@ -1814,9 +1926,22 @@ function describeAlertRule(rule) {
     if (rule.params.signal === "death") return "MACD 死叉触发";
     return "MACD 金叉/死叉触发";
   }
-  if (rule.params.zone === "overbought") return "RSI 超买 (>= 70)";
-  if (rule.params.zone === "oversold") return "RSI 超卖 (<= 30)";
-  return "RSI 超买/超卖";
+
+  if (rule.type === "rsi_zone") {
+    if (rule.params.zone === "overbought") return "RSI 超买 (>= 70)";
+    if (rule.params.zone === "oversold") return "RSI 超卖 (<= 30)";
+    return "RSI 超买/超卖";
+  }
+
+  if (rule.type === "kdj_cross") {
+    if (rule.params.signal === "golden") return "KDJ 金叉触发";
+    if (rule.params.signal === "death") return "KDJ 死叉触发";
+    return "KDJ 金叉/死叉触发";
+  }
+
+  if (rule.params.zone === "overbought") return "KDJ 超买 (J >= 100)";
+  if (rule.params.zone === "oversold") return "KDJ 超卖 (J <= 0)";
+  return "KDJ 超买/超卖";
 }
 
 function formatCooldown(ms) {
@@ -1876,6 +2001,17 @@ function monitorCardAlerts(card, previousQuote, previousTechnicals) {
       ruleId: rule.id,
       cardId: card.id,
       type: rule.type,
+      sourceIndicator:
+        match.sourceIndicator ||
+        (rule.type === "macd_cross"
+          ? "MACD"
+          : rule.type === "rsi_zone"
+            ? "RSI"
+            : rule.type === "kdj_cross" || rule.type === "kdj_zone"
+              ? "KDJ"
+              : rule.type === "ma_breakout"
+                ? "MA"
+                : "Price"),
       symbol: card.querySymbol || card.symbol || card.name,
       title: match.title,
       detail: match.detail,
@@ -1912,6 +2048,8 @@ function evaluateAlertRule(rule, context) {
   if (rule.type === "ma_breakout") return evaluateMaBreakoutRule(rule, context);
   if (rule.type === "macd_cross") return evaluateMacdRule(rule, context);
   if (rule.type === "rsi_zone") return evaluateRsiRule(rule, context);
+  if (rule.type === "kdj_cross") return evaluateKdjCrossRule(rule, context);
+  if (rule.type === "kdj_zone") return evaluateKdjZoneRule(rule, context);
   return null;
 }
 
@@ -1931,6 +2069,7 @@ function evaluatePriceRule(rule, context) {
     return {
       title: `${context.card.querySymbol || context.card.symbol} 价格上破阈值`,
       detail: `最新价 ${formatNumber(currentPrice, 2, 4)} 高于预设 ${formatNumber(threshold, 2, 4)}`,
+      sourceIndicator: "Price",
     };
   }
 
@@ -1938,6 +2077,7 @@ function evaluatePriceRule(rule, context) {
   return {
     title: `${context.card.querySymbol || context.card.symbol} 价格下破阈值`,
     detail: `最新价 ${formatNumber(currentPrice, 2, 4)} 低于预设 ${formatNumber(threshold, 2, 4)}`,
+    sourceIndicator: "Price",
   };
 }
 
@@ -1956,6 +2096,7 @@ function evaluateChangeRule(rule, context) {
   return {
     title: `${context.card.querySymbol || context.card.symbol} 涨跌幅触发`,
     detail: `当前单日涨跌幅 ${formatSigned(currentPct)}% 已超过 ${formatNumber(threshold, 1, 1)}%`,
+    sourceIndicator: "Change",
   };
 }
 
@@ -1977,6 +2118,7 @@ function evaluateMaBreakoutRule(rule, context) {
   return {
     title: `${context.card.querySymbol || context.card.symbol} ${crossUp ? "上破" : "下破"} ${maKey.toUpperCase()}`,
     detail: `价格 ${formatNumber(currentPrice, 2, 4)}，${maKey.toUpperCase()} ${formatNumber(currentMa, 2, 4)}`,
+    sourceIndicator: "MA",
   };
 }
 
@@ -1999,6 +2141,7 @@ function evaluateMacdRule(rule, context) {
       3,
       3
     )}`,
+    sourceIndicator: "MACD",
   };
 }
 
@@ -2015,6 +2158,56 @@ function evaluateRsiRule(rule, context) {
   return {
     title: `${context.card.querySymbol || context.card.symbol} RSI ${zone}`,
     detail: `RSI14 当前 ${formatNumber(currentRsi, 1, 1)}，进入 ${zone} 区间`,
+    sourceIndicator: "RSI",
+  };
+}
+
+function evaluateKdjCrossRule(rule, context) {
+  const current = context.currentTechnicals?.kdj || null;
+  const previous = context.previousTechnicals?.kdj || null;
+  if (!current || !previous) return null;
+
+  const prevK = toFiniteNumber(previous.k);
+  const prevD = toFiniteNumber(previous.d);
+  const currK = toFiniteNumber(current.k);
+  const currD = toFiniteNumber(current.d);
+  if (![prevK, prevD, currK, currD].every((value) => Number.isFinite(value))) return null;
+
+  const isGolden = prevK < prevD && currK >= currD;
+  const isDeath = prevK > prevD && currK <= currD;
+  if (!isGolden && !isDeath) return null;
+  if (rule.params.signal === "golden" && !isGolden) return null;
+  if (rule.params.signal === "death" && !isDeath) return null;
+
+  return {
+    title: `${context.card.querySymbol || context.card.symbol} KDJ ${isGolden ? "金叉" : "死叉"}`,
+    detail: `K/D/J: ${formatNumber(currK, 1, 1)} / ${formatNumber(currD, 1, 1)} / ${formatNumber(
+      current.j,
+      1,
+      1
+    )}`,
+    sourceIndicator: "KDJ",
+  };
+}
+
+function evaluateKdjZoneRule(rule, context) {
+  const current = context.currentTechnicals?.kdj || null;
+  const previous = context.previousTechnicals?.kdj || null;
+  if (!current || !previous) return null;
+
+  const currentJ = toFiniteNumber(current.j);
+  const previousJ = toFiniteNumber(previous.j);
+  if (!Number.isFinite(currentJ) || !Number.isFinite(previousJ)) return null;
+
+  const currentMatch = isKdjZoneMatched(currentJ, rule.params.zone);
+  const previousMatch = isKdjZoneMatched(previousJ, rule.params.zone);
+  if (!currentMatch || previousMatch) return null;
+
+  const zone = currentJ >= 100 ? "超买" : "超卖";
+  return {
+    title: `${context.card.querySymbol || context.card.symbol} KDJ ${zone}`,
+    detail: `KDJ J 当前 ${formatNumber(currentJ, 1, 1)}，进入 ${zone} 区间`,
+    sourceIndicator: "KDJ",
   };
 }
 
@@ -2028,6 +2221,12 @@ function isRsiZoneMatched(rsi, zone) {
   if (zone === "overbought") return rsi >= 70;
   if (zone === "oversold") return rsi <= 30;
   return rsi >= 70 || rsi <= 30;
+}
+
+function isKdjZoneMatched(jValue, zone) {
+  if (zone === "overbought") return jValue >= 100;
+  if (zone === "oversold") return jValue <= 0;
+  return jValue >= 100 || jValue <= 0;
 }
 
 function emitAlertSignal() {
@@ -2077,11 +2276,17 @@ function countTodayAlerts(history) {
 }
 
 function toFiniteNumber(value) {
+  if (typeof coreUtils.toFiniteNumber === "function") {
+    return coreUtils.toFiniteNumber(value);
+  }
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 }
 
 function numberOrNull(value) {
+  if (typeof coreUtils.numberOrNull === "function") {
+    return coreUtils.numberOrNull(value);
+  }
   return toFiniteNumber(value);
 }
 
@@ -3016,75 +3221,24 @@ function describeKdjSignal(kdj) {
 }
 
 function calculateKdjSnapshot(bars, period = 9) {
-  if (!Array.isArray(bars) || bars.length < period) {
-    return {
-      k: null,
-      d: null,
-      j: null,
-      previousK: null,
-      previousD: null,
-      previousJ: null,
-    };
+  if (typeof indicatorUtils.calculateKdjSnapshot === "function") {
+    return indicatorUtils.calculateKdjSnapshot(bars, period);
   }
-
-  let k = 50;
-  let d = 50;
-  const points = [];
-
-  for (let index = 0; index < bars.length; index += 1) {
-    const bar = bars[index];
-    const close = numberOrNull(bar?.close);
-    if (!Number.isFinite(close) || index + 1 < period) {
-      points.push(null);
-      continue;
-    }
-
-    const window = bars.slice(index + 1 - period, index + 1);
-    const lows = window.map((item) => numberOrNull(item?.low)).filter((value) => Number.isFinite(value));
-    const highs = window.map((item) => numberOrNull(item?.high)).filter((value) => Number.isFinite(value));
-    if (!lows.length || !highs.length) {
-      points.push(null);
-      continue;
-    }
-
-    const llv = Math.min(...lows);
-    const hhv = Math.max(...highs);
-    const denominator = hhv - llv;
-    const rsv = denominator <= 0 ? 50 : ((close - llv) / denominator) * 100;
-
-    k = (2 * k + rsv) / 3;
-    d = (2 * d + k) / 3;
-    const j = 3 * k - 2 * d;
-    points.push({ k, d, j });
-  }
-
-  let current = null;
-  let previous = null;
-  for (let index = points.length - 1; index >= 0; index -= 1) {
-    if (!points[index]) continue;
-    if (!current) {
-      current = points[index];
-      continue;
-    }
-    previous = points[index];
-    break;
-  }
-
   return {
-    k: numberOrNull(current?.k),
-    d: numberOrNull(current?.d),
-    j: numberOrNull(current?.j),
-    previousK: numberOrNull(previous?.k),
-    previousD: numberOrNull(previous?.d),
-    previousJ: numberOrNull(previous?.j),
+    k: null,
+    d: null,
+    j: null,
+    previousK: null,
+    previousD: null,
+    previousJ: null,
   };
 }
 
 function calculateSma(values, period) {
-  if (!Array.isArray(values) || values.length < period) return null;
-  const window = values.slice(-period);
-  const sum = window.reduce((acc, value) => acc + value, 0);
-  return sum / period;
+  if (typeof indicatorUtils.calculateSma === "function") {
+    return indicatorUtils.calculateSma(values, period);
+  }
+  return null;
 }
 
 function calculateMacdSnapshot(values) {
@@ -3124,51 +3278,17 @@ function calculateMacdSnapshot(values) {
 }
 
 function calculateEmaSeries(values, period) {
-  if (!Array.isArray(values) || !values.length) return [];
-
-  const multiplier = 2 / (period + 1);
-  let prev = Number(values[0]);
-
-  return values.map((value, index) => {
-    const current = Number(value);
-    if (!Number.isFinite(current)) return prev;
-    if (index === 0 || !Number.isFinite(prev)) {
-      prev = current;
-      return current;
-    }
-    prev = current * multiplier + prev * (1 - multiplier);
-    return prev;
-  });
+  if (typeof indicatorUtils.calculateEmaSeries === "function") {
+    return indicatorUtils.calculateEmaSeries(values, period);
+  }
+  return [];
 }
 
 function calculateRsi(values, period) {
-  if (!Array.isArray(values) || values.length <= period) return null;
-
-  let gain = 0;
-  let loss = 0;
-  for (let index = 1; index <= period; index += 1) {
-    const delta = values[index] - values[index - 1];
-    if (delta >= 0) {
-      gain += delta;
-    } else {
-      loss -= delta;
-    }
+  if (typeof indicatorUtils.calculateRsi === "function") {
+    return indicatorUtils.calculateRsi(values, period);
   }
-
-  let avgGain = gain / period;
-  let avgLoss = loss / period;
-
-  for (let index = period + 1; index < values.length; index += 1) {
-    const delta = values[index] - values[index - 1];
-    const nextGain = delta > 0 ? delta : 0;
-    const nextLoss = delta < 0 ? -delta : 0;
-    avgGain = (avgGain * (period - 1) + nextGain) / period;
-    avgLoss = (avgLoss * (period - 1) + nextLoss) / period;
-  }
-
-  if (avgLoss === 0) return 100;
-  const rs = avgGain / avgLoss;
-  return 100 - 100 / (1 + rs);
+  return null;
 }
 
 function getDateKey(timestamp) {
@@ -3188,35 +3308,10 @@ function parseCardVisualSize(value) {
 }
 
 function toYahooSymbol(input) {
-  const raw = String(input || "").trim().toUpperCase();
-
-  if (/^\d{6}\.(SH|SS|SZ)$/.test(raw)) {
-    const [code, suffix] = raw.split(".");
-    return `${code}.${suffix === "SH" ? "SS" : suffix}`;
+  if (typeof coreUtils.toYahooSymbol === "function") {
+    return coreUtils.toYahooSymbol(input);
   }
-
-  if (/^(SH|SZ)\d{6}$/.test(raw)) {
-    return `${raw.slice(2)}.${raw.startsWith("SH") ? "SS" : "SZ"}`;
-  }
-
-  if (/^\d{6}$/.test(raw)) {
-    return `${raw}.${raw.startsWith("6") ? "SS" : "SZ"}`;
-  }
-
-  if (/^HK\d{4,5}$/.test(raw)) {
-    return `${raw.slice(2).padStart(4, "0")}.HK`;
-  }
-
-  if (/^\d{4,5}\.HK$/.test(raw)) {
-    const [code] = raw.split(".");
-    return `${code.padStart(4, "0")}.HK`;
-  }
-
-  if (/^\d{4,5}$/.test(raw)) {
-    return `${raw.padStart(4, "0")}.HK`;
-  }
-
-  return raw;
+  return String(input || "").trim().toUpperCase();
 }
 
 function normalizeErrorMessage(error) {
@@ -3286,6 +3381,9 @@ function getTimeFormatter(timeZone) {
 }
 
 function formatNumber(value, minDigits = 2, maxDigits = 2) {
+  if (typeof coreUtils.formatNumber === "function") {
+    return coreUtils.formatNumber(value, minDigits, maxDigits);
+  }
   if (value == null || Number.isNaN(value)) return "--";
   return Number(value).toLocaleString(undefined, {
     minimumFractionDigits: minDigits,
@@ -3294,26 +3392,25 @@ function formatNumber(value, minDigits = 2, maxDigits = 2) {
 }
 
 function formatSigned(value) {
+  if (typeof coreUtils.formatSigned === "function") {
+    return coreUtils.formatSigned(value);
+  }
   if (value == null || Number.isNaN(value)) return "--";
-  const abs = Math.abs(value);
-  const fixed = abs.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-  return `${value >= 0 ? "+" : "-"}${fixed}`;
+  return `${value >= 0 ? "+" : "-"}${Math.abs(value).toFixed(2)}`;
 }
 
 function formatSignedFixed(value, digits = 2) {
+  if (typeof coreUtils.formatSignedFixed === "function") {
+    return coreUtils.formatSignedFixed(value, digits);
+  }
   if (value == null || Number.isNaN(value)) return "--";
-  const abs = Math.abs(value);
-  const fixed = abs.toLocaleString(undefined, {
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits,
-  });
-  return `${value >= 0 ? "+" : "-"}${fixed}`;
+  return `${value >= 0 ? "+" : "-"}${Math.abs(value).toFixed(digits)}`;
 }
 
 function formatCompact(value) {
+  if (typeof coreUtils.formatCompact === "function") {
+    return coreUtils.formatCompact(value);
+  }
   if (value == null || Number.isNaN(value)) return "--";
   return Number(value).toLocaleString(undefined, {
     notation: "compact",
@@ -3360,12 +3457,10 @@ function buildPnlRatioValue(currentPrice, costPrice) {
 }
 
 function escapeHtml(value) {
-  return String(value ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/\"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+  if (typeof coreUtils.escapeHtml === "function") {
+    return coreUtils.escapeHtml(value);
+  }
+  return String(value ?? "");
 }
 
 function buildMarketClosedStatus(label) {
@@ -3373,15 +3468,10 @@ function buildMarketClosedStatus(label) {
 }
 
 function debounce(fn, waitMs) {
-  let timer = null;
-  return (...args) =>
-    new Promise((resolve) => {
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(async () => {
-        timer = null;
-        resolve(await fn(...args));
-      }, waitMs);
-    });
+  if (typeof coreUtils.debounce === "function") {
+    return coreUtils.debounce(fn, waitMs);
+  }
+  return fn;
 }
 
 init().catch(() => {

--- a/core/indicator-utils.js
+++ b/core/indicator-utils.js
@@ -1,0 +1,187 @@
+(function initIndicatorCore(root) {
+  const indicatorCore = {
+    calculateSma,
+    calculateSmaAt,
+    calculateSmaSeries,
+    calculateEmaSeries,
+    calculateRsi,
+    calculateRsiSeries,
+    calculateKdjSnapshot,
+  };
+
+  root.DashboardIndicatorCore = Object.assign({}, root.DashboardIndicatorCore || {}, indicatorCore);
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = indicatorCore;
+  }
+
+  function calculateSma(values, period) {
+    if (!Array.isArray(values) || values.length < period) return null;
+    const window = values.slice(-period);
+    const sum = window.reduce((acc, value) => acc + value, 0);
+    return sum / period;
+  }
+
+  function calculateSmaAt(values, index, period) {
+    if (!Array.isArray(values) || index < period - 1) return null;
+    const window = values.slice(index + 1 - period, index + 1);
+    const sum = window.reduce((acc, value) => acc + value, 0);
+    return sum / period;
+  }
+
+  function calculateSmaSeries(values, period) {
+    if (!Array.isArray(values) || !values.length) return [];
+    return values.map((_, index) => calculateSmaAt(values, index, period));
+  }
+
+  function calculateEmaSeries(values, period) {
+    if (!Array.isArray(values) || !values.length) return [];
+
+    const multiplier = 2 / (period + 1);
+    let prev = Number(values[0]);
+
+    return values.map((value, index) => {
+      const current = Number(value);
+      if (!Number.isFinite(current)) return prev;
+      if (index === 0 || !Number.isFinite(prev)) {
+        prev = current;
+        return current;
+      }
+      prev = current * multiplier + prev * (1 - multiplier);
+      return prev;
+    });
+  }
+
+  function calculateRsi(values, period) {
+    if (!Array.isArray(values) || values.length <= period) return null;
+
+    let gain = 0;
+    let loss = 0;
+    for (let index = 1; index <= period; index += 1) {
+      const delta = values[index] - values[index - 1];
+      if (delta >= 0) {
+        gain += delta;
+      } else {
+        loss -= delta;
+      }
+    }
+
+    let avgGain = gain / period;
+    let avgLoss = loss / period;
+
+    for (let index = period + 1; index < values.length; index += 1) {
+      const delta = values[index] - values[index - 1];
+      const nextGain = delta > 0 ? delta : 0;
+      const nextLoss = delta < 0 ? -delta : 0;
+      avgGain = (avgGain * (period - 1) + nextGain) / period;
+      avgLoss = (avgLoss * (period - 1) + nextLoss) / period;
+    }
+
+    if (avgLoss === 0) return 100;
+    const rs = avgGain / avgLoss;
+    return 100 - 100 / (1 + rs);
+  }
+
+  function calculateRsiSeries(values, period) {
+    if (!Array.isArray(values) || !values.length) return [];
+    if (period <= 0) return values.map(() => null);
+
+    const rsiSeries = values.map(() => null);
+    if (values.length <= period) return rsiSeries;
+
+    let gain = 0;
+    let loss = 0;
+    for (let index = 1; index <= period; index += 1) {
+      const delta = values[index] - values[index - 1];
+      if (delta >= 0) {
+        gain += delta;
+      } else {
+        loss -= delta;
+      }
+    }
+
+    let avgGain = gain / period;
+    let avgLoss = loss / period;
+    rsiSeries[period] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+
+    for (let index = period + 1; index < values.length; index += 1) {
+      const delta = values[index] - values[index - 1];
+      const nextGain = delta > 0 ? delta : 0;
+      const nextLoss = delta < 0 ? -delta : 0;
+      avgGain = (avgGain * (period - 1) + nextGain) / period;
+      avgLoss = (avgLoss * (period - 1) + nextLoss) / period;
+      rsiSeries[index] = avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss);
+    }
+
+    return rsiSeries;
+  }
+
+  function calculateKdjSnapshot(bars, period = 9) {
+    const numberOrNull = root.DashboardCore?.numberOrNull || ((value) => {
+      const num = Number(value);
+      return Number.isFinite(num) ? num : null;
+    });
+
+    if (!Array.isArray(bars) || bars.length < period) {
+      return {
+        k: null,
+        d: null,
+        j: null,
+        previousK: null,
+        previousD: null,
+        previousJ: null,
+      };
+    }
+
+    let k = 50;
+    let d = 50;
+    const points = [];
+
+    for (let index = 0; index < bars.length; index += 1) {
+      const bar = bars[index];
+      const close = numberOrNull(bar?.close);
+      if (!Number.isFinite(close) || index + 1 < period) {
+        points.push(null);
+        continue;
+      }
+
+      const window = bars.slice(index + 1 - period, index + 1);
+      const lows = window.map((item) => numberOrNull(item?.low)).filter((value) => Number.isFinite(value));
+      const highs = window.map((item) => numberOrNull(item?.high)).filter((value) => Number.isFinite(value));
+      if (!lows.length || !highs.length) {
+        points.push(null);
+        continue;
+      }
+
+      const llv = Math.min(...lows);
+      const hhv = Math.max(...highs);
+      const denominator = hhv - llv;
+      const rsv = denominator <= 0 ? 50 : ((close - llv) / denominator) * 100;
+
+      k = (2 * k + rsv) / 3;
+      d = (2 * d + k) / 3;
+      const j = 3 * k - 2 * d;
+      points.push({ k, d, j });
+    }
+
+    let current = null;
+    let previous = null;
+    for (let index = points.length - 1; index >= 0; index -= 1) {
+      if (!points[index]) continue;
+      if (!current) {
+        current = points[index];
+        continue;
+      }
+      previous = points[index];
+      break;
+    }
+
+    return {
+      k: numberOrNull(current?.k),
+      d: numberOrNull(current?.d),
+      j: numberOrNull(current?.j),
+      previousK: numberOrNull(previous?.k),
+      previousD: numberOrNull(previous?.d),
+      previousJ: numberOrNull(previous?.j),
+    };
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/core/shared-utils.js
+++ b/core/shared-utils.js
@@ -1,0 +1,116 @@
+(function initDashboardCore(root) {
+  const core = {
+    toFiniteNumber,
+    numberOrNull,
+    toYahooSymbol,
+    escapeHtml,
+    debounce,
+    formatNumber,
+    formatSigned,
+    formatSignedFixed,
+    formatCompact,
+  };
+
+  root.DashboardCore = Object.assign({}, root.DashboardCore || {}, core);
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = core;
+  }
+
+  function toFiniteNumber(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  function numberOrNull(value) {
+    return toFiniteNumber(value);
+  }
+
+  function toYahooSymbol(input) {
+    const raw = String(input || "").trim().toUpperCase();
+
+    if (/^\d{6}\.(SH|SS|SZ)$/.test(raw)) {
+      const [code, suffix] = raw.split(".");
+      return `${code}.${suffix === "SH" ? "SS" : suffix}`;
+    }
+
+    if (/^(SH|SZ)\d{6}$/.test(raw)) {
+      return `${raw.slice(2)}.${raw.startsWith("SH") ? "SS" : "SZ"}`;
+    }
+
+    if (/^\d{6}$/.test(raw)) {
+      return `${raw}.${raw.startsWith("6") ? "SS" : "SZ"}`;
+    }
+
+    if (/^HK\d{4,5}$/.test(raw)) {
+      return `${raw.slice(2).padStart(4, "0")}.HK`;
+    }
+
+    if (/^\d{4,5}\.HK$/.test(raw)) {
+      const [code] = raw.split(".");
+      return `${code.padStart(4, "0")}.HK`;
+    }
+
+    if (/^\d{4,5}$/.test(raw)) {
+      return `${raw.padStart(4, "0")}.HK`;
+    }
+
+    return raw;
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function debounce(fn, waitMs) {
+    let timer = null;
+    return (...args) =>
+      new Promise((resolve) => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(async () => {
+          timer = null;
+          resolve(await fn(...args));
+        }, waitMs);
+      });
+  }
+
+  function formatNumber(value, minDigits = 2, maxDigits = 2) {
+    if (value == null || Number.isNaN(value)) return "--";
+    return Number(value).toLocaleString(undefined, {
+      minimumFractionDigits: minDigits,
+      maximumFractionDigits: maxDigits,
+    });
+  }
+
+  function formatSigned(value) {
+    if (value == null || Number.isNaN(value)) return "--";
+    const abs = Math.abs(value);
+    const fixed = abs.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    return `${value >= 0 ? "+" : "-"}${fixed}`;
+  }
+
+  function formatSignedFixed(value, digits = 2) {
+    if (value == null || Number.isNaN(value)) return "--";
+    const abs = Math.abs(value);
+    const fixed = abs.toLocaleString(undefined, {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    });
+    return `${value >= 0 ? "+" : "-"}${fixed}`;
+  }
+
+  function formatCompact(value) {
+    if (value == null || Number.isNaN(value)) return "--";
+    return Number(value).toLocaleString(undefined, {
+      notation: "compact",
+      maximumFractionDigits: 2,
+    });
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/core/signal-policy.js
+++ b/core/signal-policy.js
@@ -1,0 +1,28 @@
+(function initSignalPolicy(root) {
+  const core = {
+    shouldAllowSameBarEntry,
+    signalSourceForStrategy,
+  };
+
+  root.DashboardSignalPolicyCore = Object.assign({}, root.DashboardSignalPolicyCore || {}, core);
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = core;
+  }
+
+  function shouldAllowSameBarEntry(execution, hadExitOnCurrentBar) {
+    if (!hadExitOnCurrentBar) return true;
+    if (!execution || typeof execution !== "object") return false;
+    return execution.noSameBarReentry === false;
+  }
+
+  function signalSourceForStrategy(strategyType, direction, reasonCode = "") {
+    if (reasonCode === "stop_loss" || reasonCode === "take_profit" || reasonCode === "max_hold") {
+      return "Risk";
+    }
+    if (strategyType === "ma_cross") return "MA";
+    if (strategyType === "macd_cross") return "MACD";
+    if (strategyType === "rsi_reversion") return "RSI";
+    if (strategyType === "price_breakout") return direction === "buy" ? "Breakout" : "Breakdown";
+    return "Composite";
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/core/state-merge.js
+++ b/core/state-merge.js
@@ -1,0 +1,151 @@
+(function initStateMerge(root) {
+  const core = {
+    mergeDashboardState,
+  };
+
+  root.DashboardStateMergeCore = Object.assign({}, root.DashboardStateMergeCore || {}, core);
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = core;
+  }
+
+  function mergeDashboardState(localState, remoteState, options = {}) {
+    const historyLimit = Number.isFinite(Number(options.alertHistoryLimit))
+      ? Math.max(1, Math.floor(Number(options.alertHistoryLimit)))
+      : 180;
+    const local = localState && typeof localState === "object" ? localState : {};
+    const remote = remoteState && typeof remoteState === "object" ? remoteState : {};
+
+    const localCards = Array.isArray(local.cards) ? local.cards : [];
+    const remoteCards = Array.isArray(remote.cards) ? remote.cards : [];
+
+    const cards = mergeCardsByRecency(localCards, remoteCards);
+    const alerts = mergeAlerts(local.alerts, remote.alerts, historyLimit);
+
+    return {
+      cards,
+      alerts,
+      revision: Number.isFinite(Number(remote.revision)) ? Number(remote.revision) : Number(remote.updatedAt) || 0,
+      updatedAt: Date.now(),
+    };
+  }
+
+  function mergeCardsByRecency(localCards, remoteCards) {
+    const merged = new Map();
+
+    remoteCards.forEach((card) => {
+      if (!card || typeof card !== "object") return;
+      const id = String(card.id || "");
+      if (!id) return;
+      merged.set(id, card);
+    });
+
+    localCards.forEach((card) => {
+      if (!card || typeof card !== "object") return;
+      const id = String(card.id || "");
+      if (!id) return;
+      const remoteCard = merged.get(id);
+      if (!remoteCard) {
+        merged.set(id, card);
+        return;
+      }
+
+      const localAt = resolveCardFreshness(card);
+      const remoteAt = resolveCardFreshness(remoteCard);
+      if (localAt >= remoteAt) {
+        merged.set(id, card);
+      }
+    });
+
+    return Array.from(merged.values());
+  }
+
+  function resolveCardFreshness(card) {
+    if (!card || typeof card !== "object") return 0;
+    const candidates = [
+      Number(card.updatedAt),
+      Number(card.lastUpdatedAt),
+      Number(card.dailySeriesUpdatedAt),
+      Number(card.quote?.timestamp),
+      Number(card.createdAt),
+    ].filter((value) => Number.isFinite(value) && value > 0);
+    return candidates.length ? Math.max(...candidates) : 0;
+  }
+
+  function mergeAlerts(localAlerts, remoteAlerts, historyLimit) {
+    const fallback = {
+      enabled: true,
+      silentMode: true,
+      lowPowerMode: false,
+      soundEnabled: false,
+      vibrationEnabled: false,
+      panelCollapsed: false,
+      rules: [],
+      history: [],
+      totalTriggered: 0,
+    };
+
+    const local = localAlerts && typeof localAlerts === "object" ? localAlerts : {};
+    const remote = remoteAlerts && typeof remoteAlerts === "object" ? remoteAlerts : {};
+
+    const rules = mergeById(
+      Array.isArray(local.rules) ? local.rules : [],
+      Array.isArray(remote.rules) ? remote.rules : [],
+      (item) => Math.max(Number(item.createdAt) || 0, Number(item.lastTriggeredAt) || 0)
+    );
+
+    const history = mergeById(
+      Array.isArray(local.history) ? local.history : [],
+      Array.isArray(remote.history) ? remote.history : [],
+      (item) => Number(item.triggeredAt) || 0
+    )
+      .sort((left, right) => (Number(right.triggeredAt) || 0) - (Number(left.triggeredAt) || 0))
+      .slice(0, historyLimit);
+
+    const localTotal = Number(local.totalTriggered);
+    const remoteTotal = Number(remote.totalTriggered);
+    const totalTriggered = Math.max(
+      Number.isFinite(localTotal) ? localTotal : 0,
+      Number.isFinite(remoteTotal) ? remoteTotal : 0,
+      history.length
+    );
+
+    return {
+      ...fallback,
+      ...remote,
+      ...local,
+      rules,
+      history,
+      totalTriggered,
+    };
+  }
+
+  function mergeById(localItems, remoteItems, freshnessResolver) {
+    const map = new Map();
+
+    remoteItems.forEach((item) => {
+      if (!item || typeof item !== "object") return;
+      const id = String(item.id || "");
+      if (!id) return;
+      map.set(id, item);
+    });
+
+    localItems.forEach((item) => {
+      if (!item || typeof item !== "object") return;
+      const id = String(item.id || "");
+      if (!id) return;
+      const prev = map.get(id);
+      if (!prev) {
+        map.set(id, item);
+        return;
+      }
+
+      const localAt = Number(freshnessResolver(item)) || 0;
+      const remoteAt = Number(freshnessResolver(prev)) || 0;
+      if (localAt >= remoteAt) {
+        map.set(id, item);
+      }
+    });
+
+    return Array.from(map.values());
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/index.html
+++ b/index.html
@@ -92,6 +92,8 @@
                 <option value="ma_breakout">MA 突破检测</option>
                 <option value="macd_cross">MACD 金叉/死叉</option>
                 <option value="rsi_zone">RSI 超买超卖</option>
+                <option value="kdj_cross">KDJ 金叉/死叉</option>
+                <option value="kdj_zone">KDJ 超买超卖</option>
               </select>
             </label>
             <div id="alertRuleParams" class="alert-rule-params"></div>
@@ -300,6 +302,10 @@
       </article>
     </template>
 
+    <script src="./core/shared-utils.js"></script>
+    <script src="./core/indicator-utils.js"></script>
+    <script src="./core/state-merge.js"></script>
+    <script src="./core/signal-policy.js"></script>
     <script src="./app.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "price_query",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test tests/*.test.js",
+    "check": "node --check app.js && node --check analysis.js && node --check server.js"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -10,6 +10,28 @@ const EASTMONEY_SEARCH_TOKEN = "D43BF722C8E33BDC906FB84D85E326E8";
 const EASTMONEY_HISTORY_TOKEN = "fa5fd1943c7b386f172d6893dbfba10b";
 const QUOTE_TOPICS = new Set(["mixed", "economics", "philosophy", "engineering"]);
 const ALERT_HISTORY_LIMIT = 200;
+const DEFAULT_STATE_REVISION = 0;
+const UPSTREAM_TIMEOUT_MS = {
+  quote: 4500,
+  history: 7000,
+  search: 3500,
+  hn: 5000,
+};
+const UPSTREAM_RETRIES = {
+  quote: 1,
+  history: 1,
+  search: 1,
+  hn: 1,
+};
+const CACHE_TTL_MS = {
+  hn_top: 45 * 1000,
+  stock_search: 8 * 1000,
+};
+const CACHE_STALE_MS = {
+  hn_top: 2 * 60 * 1000,
+  stock_search: 20 * 1000,
+};
+const endpointCache = new Map();
 const QUOTE_LIBRARY = {
   economics: [
     {
@@ -78,6 +100,14 @@ const QUOTE_LIBRARY = {
     },
   ],
 };
+
+class UpstreamFetchError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "UpstreamFetchError";
+    this.details = details;
+  }
+}
 
 const MIME = {
   ".html": "text/html; charset=utf-8",
@@ -150,19 +180,21 @@ async function handleQuote(url, res) {
       () => fetchTencentQuote(local),
       () => fetchYahooQuote(toYahooSymbol(input)),
     ];
+    const sourceErrors = [];
 
     for (const fn of attempts) {
       try {
         const quote = await fn();
         sendJson(res, 200, quote);
         return;
-      } catch {
-        // Continue to next source.
+      } catch (error) {
+        sourceErrors.push(normalizeUpstreamError(error));
       }
     }
 
     sendJson(res, 502, {
       error: `无法获取 ${input} 行情（数据源不可达或代码无效）`,
+      details: sourceErrors,
     });
     return;
   }
@@ -187,20 +219,41 @@ async function handleState(req, res) {
   if (req.method === "POST") {
     const payload = await readJsonBody(req);
     if (!payload || !Array.isArray(payload.cards)) {
-      sendJson(res, 400, { error: "状态格式错误，要求 { cards: [] }" });
+      sendJson(res, 400, { error: "状态格式错误，要求 { cards: [] , revision }" });
       return;
     }
 
     const currentState = await readStateFile();
+    const incomingRevision = Number(payload.revision);
+    if (!Number.isFinite(incomingRevision)) {
+      sendJson(res, 400, {
+        error: "缺少 revision 字段",
+        revision: currentState.revision,
+      });
+      return;
+    }
+    if (incomingRevision !== Number(currentState.revision || DEFAULT_STATE_REVISION)) {
+      sendJson(res, 409, {
+        error: "state revision conflict",
+        cards: currentState.cards,
+        alerts: currentState.alerts,
+        revision: currentState.revision,
+        updatedAt: currentState.updatedAt || Date.now(),
+      });
+      return;
+    }
+
     const normalizedAlerts = Object.prototype.hasOwnProperty.call(payload, "alerts")
       ? normalizeAlertState(payload.alerts)
       : normalizeAlertState(currentState.alerts);
+    const nextRevision = Number(currentState.revision || DEFAULT_STATE_REVISION) + 1;
     await writeStateFile({
       cards: payload.cards,
       alerts: normalizedAlerts,
+      revision: nextRevision,
       updatedAt: Date.now(),
     });
-    sendJson(res, 200, { ok: true });
+    sendJson(res, 200, { ok: true, revision: nextRevision });
     return;
   }
 
@@ -242,10 +295,23 @@ async function handleStockSearch(url, res) {
     token: EASTMONEY_SEARCH_TOKEN,
     count: String(limit),
   });
+  const endpoint = `https://searchapi.eastmoney.com/api/suggest/get?${params.toString()}`;
+  const cacheKey = `stock-search:${query.toUpperCase()}:${limit}`;
 
   try {
-    const endpoint = `https://searchapi.eastmoney.com/api/suggest/get?${params.toString()}`;
-    const payload = await fetchJson(endpoint);
+    const payload = await fetchCachedWithSwr(
+      cacheKey,
+      () =>
+        fetchJson(endpoint, {
+          source: "eastmoney-search",
+          timeoutMs: UPSTREAM_TIMEOUT_MS.search,
+          retries: UPSTREAM_RETRIES.search,
+        }),
+      {
+        ttlMs: CACHE_TTL_MS.stock_search,
+        staleMs: CACHE_STALE_MS.stock_search,
+      }
+    );
     const rows = Array.isArray(payload?.QuotationCodeTable?.Data)
       ? payload.QuotationCodeTable.Data
       : [];
@@ -288,24 +354,54 @@ async function handleStockHistory(url, res) {
 
 async function handleHnTop(url, res) {
   const limit = clampHnLimit(url.searchParams.get("limit"));
-  const topIds = await fetchJson(HN_TOP_STORIES_URL);
+  const cacheKey = `hn-top:${limit}`;
+  let items = [];
 
-  if (!Array.isArray(topIds) || !topIds.length) {
-    sendJson(res, 502, { error: "Hacker News 热门列表为空" });
+  try {
+    items = await fetchCachedWithSwr(
+      cacheKey,
+      async () => {
+        const topIds = await fetchJson(HN_TOP_STORIES_URL, {
+          source: "hn-topstories",
+          timeoutMs: UPSTREAM_TIMEOUT_MS.hn,
+          retries: UPSTREAM_RETRIES.hn,
+        });
+
+        if (!Array.isArray(topIds) || !topIds.length) {
+          throw new UpstreamFetchError("Hacker News 热门列表为空", {
+            source: "hn-topstories",
+          });
+        }
+
+        const ids = topIds.slice(0, limit);
+        const resolved = await Promise.all(
+          ids.map(async (id) => {
+            try {
+              const item = await fetchJson(`https://hacker-news.firebaseio.com/v0/item/${id}.json`, {
+                source: "hn-item",
+                timeoutMs: UPSTREAM_TIMEOUT_MS.hn,
+                retries: UPSTREAM_RETRIES.hn,
+              });
+              return normalizeHnItem(item);
+            } catch {
+              return null;
+            }
+          })
+        );
+        return resolved.filter(Boolean);
+      },
+      {
+        ttlMs: CACHE_TTL_MS.hn_top,
+        staleMs: CACHE_STALE_MS.hn_top,
+      }
+    );
+  } catch (error) {
+    sendJson(res, 502, {
+      error: "Hacker News 热门列表获取失败",
+      details: [normalizeUpstreamError(error)],
+    });
     return;
   }
-
-  const ids = topIds.slice(0, limit);
-  const items = await Promise.all(
-    ids.map(async (id) => {
-      try {
-        const item = await fetchJson(`https://hacker-news.firebaseio.com/v0/item/${id}.json`);
-        return normalizeHnItem(item);
-      } catch {
-        return null;
-      }
-    })
-  );
 
   sendJson(res, 200, {
     items: items.filter(Boolean),
@@ -342,12 +438,11 @@ async function fetchEastMoneyQuote(local) {
   const fields = "f43,f44,f45,f47,f57,f58,f60,f124";
   const url = `https://push2.eastmoney.com/api/qt/stock/get?invt=2&fltt=2&secid=${secid}&fields=${fields}`;
 
-  const response = await fetch(url, { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error(`EastMoney HTTP ${response.status}`);
-  }
-
-  const payload = await response.json();
+  const payload = await fetchJson(url, {
+    source: "eastmoney-quote",
+    timeoutMs: UPSTREAM_TIMEOUT_MS.quote,
+    retries: UPSTREAM_RETRIES.quote,
+  });
   const data = payload?.data;
   if (!data || data.f43 == null || data.f43 === "-") {
     throw new Error("EastMoney 无有效数据");
@@ -379,12 +474,11 @@ async function fetchTencentQuote(local) {
   const query = `${local.market.toLowerCase()}${local.code}`;
   const url = `https://qt.gtimg.cn/q=${query}`;
 
-  const response = await fetch(url, { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error(`Tencent HTTP ${response.status}`);
-  }
-
-  const raw = await response.text();
+  const raw = await fetchText(url, {
+    source: "tencent-quote",
+    timeoutMs: UPSTREAM_TIMEOUT_MS.quote,
+    retries: UPSTREAM_RETRIES.quote,
+  });
   const matched = raw.match(/="([^"]+)";/);
   if (!matched) {
     throw new Error("Tencent 响应无法解析");
@@ -422,12 +516,11 @@ async function fetchTencentQuote(local) {
 
 async function fetchYahooQuote(symbol) {
   const url = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(symbol)}`;
-  const response = await fetch(url, { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error(`Yahoo HTTP ${response.status}`);
-  }
-
-  const payload = await response.json();
+  const payload = await fetchJson(url, {
+    source: "yahoo-quote",
+    timeoutMs: UPSTREAM_TIMEOUT_MS.quote,
+    retries: UPSTREAM_RETRIES.quote,
+  });
   const quote = payload?.quoteResponse?.result?.[0];
   if (!quote || quote.regularMarketPrice == null) {
     throw new Error("Yahoo 无有效数据");
@@ -464,12 +557,11 @@ async function fetchEastMoneyHistory(local, limit) {
   });
   const url = `https://push2his.eastmoney.com/api/qt/stock/kline/get?${params.toString()}`;
 
-  const response = await fetch(url, { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error(`EastMoney History HTTP ${response.status}`);
-  }
-
-  const payload = await response.json();
+  const payload = await fetchJson(url, {
+    source: "eastmoney-history",
+    timeoutMs: UPSTREAM_TIMEOUT_MS.history,
+    retries: UPSTREAM_RETRIES.history,
+  });
   const data = payload?.data;
   const rows = Array.isArray(data?.klines) ? data.klines : [];
   const items = rows.map(parseEastMoneyKline).filter(Boolean);
@@ -498,12 +590,11 @@ async function fetchYahooHistory(symbol, limit) {
   });
   const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?${params.toString()}`;
 
-  const response = await fetch(url, { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error(`Yahoo History HTTP ${response.status}`);
-  }
-
-  const payload = await response.json();
+  const payload = await fetchJson(url, {
+    source: "yahoo-history",
+    timeoutMs: UPSTREAM_TIMEOUT_MS.history,
+    retries: UPSTREAM_RETRIES.history,
+  });
   const result = payload?.chart?.result?.[0];
   const quote = result?.indicators?.quote?.[0];
   const timestamps = Array.isArray(result?.timestamp) ? result.timestamp : [];
@@ -543,12 +634,119 @@ async function fetchYahooHistory(symbol, limit) {
   };
 }
 
-async function fetchJson(url) {
-  const response = await fetch(url, { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
+async function fetchJson(url, options = {}) {
+  const response = await fetchWithPolicy(url, {
+    ...options,
+    parseAs: "json",
+  });
+  return response.data;
+}
+
+async function fetchText(url, options = {}) {
+  const response = await fetchWithPolicy(url, {
+    ...options,
+    parseAs: "text",
+  });
+  return response.data;
+}
+
+async function fetchWithPolicy(url, options = {}) {
+  const source = String(options.source || "upstream");
+  const timeoutMs = Number.isFinite(Number(options.timeoutMs))
+    ? Math.max(800, Number(options.timeoutMs))
+    : 4000;
+  const retries = Number.isFinite(Number(options.retries))
+    ? Math.max(0, Math.floor(Number(options.retries)))
+    : 0;
+  const parseAs = options.parseAs === "text" ? "text" : "json";
+  let lastError = null;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(url, {
+        cache: "no-store",
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new UpstreamFetchError(`${source} HTTP ${response.status}`, {
+          source,
+          status: response.status,
+          retriable: response.status >= 500 || response.status === 429,
+          attempt,
+        });
+      }
+      const data = parseAs === "text" ? await response.text() : await response.json();
+      clearTimeout(timer);
+      return { data, status: response.status, source, attempts: attempt + 1 };
+    } catch (error) {
+      clearTimeout(timer);
+      const timedOut = error?.name === "AbortError";
+      const normalizedError =
+        error instanceof UpstreamFetchError
+          ? error
+          : new UpstreamFetchError(timedOut ? `${source} timeout` : normalizeError(error), {
+              source,
+              status: null,
+              retriable: true,
+              timeout: timedOut,
+              attempt,
+            });
+      lastError = normalizedError;
+      if (attempt >= retries) break;
+      const backoffMs = 120 * (attempt + 1);
+      await sleep(backoffMs);
+    }
   }
-  return response.json();
+
+  throw lastError || new UpstreamFetchError(`${source} request failed`, { source, retriable: true });
+}
+
+async function fetchCachedWithSwr(cacheKey, loader, options = {}) {
+  const ttlMs = Number.isFinite(Number(options.ttlMs)) ? Math.max(200, Number(options.ttlMs)) : 3000;
+  const staleMs = Number.isFinite(Number(options.staleMs)) ? Math.max(0, Number(options.staleMs)) : 0;
+  const now = Date.now();
+  const existing = endpointCache.get(cacheKey);
+
+  if (existing && now < existing.expiresAt) {
+    return existing.value;
+  }
+
+  if (existing && now < existing.staleUntil) {
+    if (!existing.refreshing) {
+      existing.refreshing = true;
+      Promise.resolve()
+        .then(loader)
+        .then((value) => {
+          endpointCache.set(cacheKey, {
+            value,
+            expiresAt: Date.now() + ttlMs,
+            staleUntil: Date.now() + ttlMs + staleMs,
+            refreshing: false,
+          });
+        })
+        .catch(() => {
+          existing.refreshing = false;
+        });
+    }
+    return existing.value;
+  }
+
+  const value = await loader();
+  endpointCache.set(cacheKey, {
+    value,
+    expiresAt: now + ttlMs,
+    staleUntil: now + ttlMs + staleMs,
+    refreshing: false,
+  });
+  return value;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, Math.max(0, Number(ms) || 0));
+  });
 }
 
 function parseCnSymbol(input) {
@@ -756,16 +954,33 @@ async function readStateFile() {
     const raw = await fs.readFile(STATE_FILE, "utf8");
     const parsed = JSON.parse(raw);
     if (!parsed || !Array.isArray(parsed.cards)) {
-      return { cards: [], alerts: normalizeAlertState(null) };
+      return {
+        cards: [],
+        alerts: normalizeAlertState(null),
+        revision: DEFAULT_STATE_REVISION,
+        updatedAt: Date.now(),
+      };
     }
+    const revision = Number.isFinite(Number(parsed.revision))
+      ? Number(parsed.revision)
+      : Number.isFinite(Number(parsed.updatedAt))
+        ? Number(parsed.updatedAt)
+        : DEFAULT_STATE_REVISION;
     return {
       ...parsed,
       cards: parsed.cards,
       alerts: normalizeAlertState(parsed.alerts),
+      revision,
+      updatedAt: Number.isFinite(Number(parsed.updatedAt)) ? Number(parsed.updatedAt) : Date.now(),
     };
   } catch (error) {
     if (error && error.code === "ENOENT") {
-      return { cards: [], alerts: normalizeAlertState(null) };
+      return {
+        cards: [],
+        alerts: normalizeAlertState(null),
+        revision: DEFAULT_STATE_REVISION,
+        updatedAt: Date.now(),
+      };
     }
     throw error;
   }
@@ -830,6 +1045,27 @@ function normalizeError(error) {
   if (!error) return "";
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+function normalizeUpstreamError(error) {
+  if (error instanceof UpstreamFetchError) {
+    return {
+      message: error.message,
+      source: error.details?.source || "",
+      status: error.details?.status ?? null,
+      timeout: Boolean(error.details?.timeout),
+      retriable: Boolean(error.details?.retriable),
+      attempt: Number.isFinite(Number(error.details?.attempt)) ? Number(error.details.attempt) : 0,
+    };
+  }
+  return {
+    message: normalizeError(error),
+    source: "",
+    status: null,
+    timeout: false,
+    retriable: false,
+    attempt: 0,
+  };
 }
 
 function sendJson(res, status, payload) {

--- a/tests/indicator-utils.test.js
+++ b/tests/indicator-utils.test.js
@@ -1,0 +1,44 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  calculateSma,
+  calculateSmaSeries,
+  calculateRsi,
+  calculateRsiSeries,
+  calculateKdjSnapshot,
+} = require("../core/indicator-utils.js");
+
+test("calculateSma returns expected average", () => {
+  assert.equal(calculateSma([1, 2, 3, 4, 5], 5), 3);
+  assert.equal(calculateSma([10, 20, 30], 2), 25);
+});
+
+test("calculateRsi and rsi series produce finite values on volatile data", () => {
+  const values = [10, 11, 9, 10, 12, 11, 13, 12, 11, 12, 13, 14, 13, 15, 16, 15, 17, 18, 17];
+  const rsi = calculateRsi(values, 14);
+  const series = calculateRsiSeries(values, 14);
+  assert.equal(Number.isFinite(rsi), true);
+  assert.equal(Number.isFinite(series[series.length - 1]), true);
+  assert.equal(series.length, values.length);
+});
+
+test("calculateKdjSnapshot returns current and previous points", () => {
+  const bars = Array.from({ length: 20 }).map((_, i) => ({
+    close: 10 + i * 0.2,
+    high: 10 + i * 0.25 + 0.3,
+    low: 10 + i * 0.15 - 0.2,
+  }));
+  const kdj = calculateKdjSnapshot(bars, 9);
+  assert.equal(Number.isFinite(kdj.k), true);
+  assert.equal(Number.isFinite(kdj.d), true);
+  assert.equal(Number.isFinite(kdj.j), true);
+  assert.equal(Number.isFinite(kdj.previousK), true);
+});
+
+test("calculateSmaSeries aligns size", () => {
+  const values = [1, 2, 3, 4, 5, 6];
+  const series = calculateSmaSeries(values, 3);
+  assert.equal(series.length, values.length);
+  assert.equal(series[1], null);
+  assert.equal(series[2], 2);
+});

--- a/tests/shared-utils.test.js
+++ b/tests/shared-utils.test.js
@@ -1,0 +1,16 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { toYahooSymbol } = require("../core/shared-utils.js");
+
+test("toYahooSymbol supports CN formats", () => {
+  assert.equal(toYahooSymbol("600519"), "600519.SS");
+  assert.equal(toYahooSymbol("300750"), "300750.SZ");
+  assert.equal(toYahooSymbol("SH600519"), "600519.SS");
+  assert.equal(toYahooSymbol("600519.SH"), "600519.SS");
+});
+
+test("toYahooSymbol supports HK formats", () => {
+  assert.equal(toYahooSymbol("hk00700"), "00700.HK");
+  assert.equal(toYahooSymbol("0700"), "0700.HK");
+  assert.equal(toYahooSymbol("0700.HK"), "0700.HK");
+});

--- a/tests/signal-policy.test.js
+++ b/tests/signal-policy.test.js
@@ -1,0 +1,15 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { shouldAllowSameBarEntry, signalSourceForStrategy } = require("../core/signal-policy.js");
+
+test("shouldAllowSameBarEntry respects noSameBarReentry", () => {
+  assert.equal(shouldAllowSameBarEntry({ noSameBarReentry: true }, true), false);
+  assert.equal(shouldAllowSameBarEntry({ noSameBarReentry: false }, true), true);
+  assert.equal(shouldAllowSameBarEntry({ noSameBarReentry: true }, false), true);
+});
+
+test("signalSourceForStrategy resolves source", () => {
+  assert.equal(signalSourceForStrategy("macd_cross", "buy", "signal"), "MACD");
+  assert.equal(signalSourceForStrategy("price_breakout", "sell", "signal"), "Breakdown");
+  assert.equal(signalSourceForStrategy("hybrid", "sell", "stop_loss"), "Risk");
+});

--- a/tests/state-merge.test.js
+++ b/tests/state-merge.test.js
@@ -1,0 +1,44 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { mergeDashboardState } = require("../core/state-merge.js");
+
+test("mergeDashboardState prefers newer card snapshot", () => {
+  const local = {
+    cards: [{ id: "a", name: "Local", lastUpdatedAt: 200 }],
+    alerts: { rules: [], history: [], totalTriggered: 0 },
+  };
+  const remote = {
+    cards: [{ id: "a", name: "Remote", lastUpdatedAt: 100 }],
+    alerts: { rules: [], history: [], totalTriggered: 0 },
+    revision: 5,
+  };
+  const merged = mergeDashboardState(local, remote);
+  assert.equal(merged.cards[0].name, "Local");
+  assert.equal(merged.revision, 5);
+});
+
+test("mergeDashboardState deduplicates alert rules by id", () => {
+  const local = {
+    cards: [],
+    alerts: {
+      rules: [{ id: "r1", createdAt: 200, enabled: true }],
+      history: [{ id: "h1", triggeredAt: 200 }],
+      totalTriggered: 2,
+    },
+  };
+  const remote = {
+    cards: [],
+    alerts: {
+      rules: [{ id: "r1", createdAt: 100, enabled: false }, { id: "r2", createdAt: 100, enabled: true }],
+      history: [{ id: "h1", triggeredAt: 100 }, { id: "h2", triggeredAt: 50 }],
+      totalTriggered: 1,
+    },
+    revision: 3,
+  };
+
+  const merged = mergeDashboardState(local, remote, { alertHistoryLimit: 10 });
+  assert.equal(merged.alerts.rules.length, 2);
+  assert.equal(merged.alerts.rules.find((item) => item.id === "r1").enabled, true);
+  assert.equal(merged.alerts.history.length, 2);
+  assert.equal(merged.alerts.totalTriggered, 2);
+});


### PR DESCRIPTION
## Summary
This PR implements the issue hardening bundle across data pipeline, strategy signal semantics, persistence safety, and engineering quality.

### 1) Signal conflict + provenance (Issue #2)
- Add execution flag `noSameBarReentry` (default enabled) to prevent same-bar sell-then-buy churn in backtest.
- Extend signal payload with provenance metadata (`sourceIndicator`, `reasonCode`).
- Snapshot panel now shows all same-index signals with indicator source labels.
- Chart marker tooltip now includes signal source.

### 2) Upstream timeout/retry and endpoint cache (Issues #3, #4 partial infra)
- Introduce `fetchWithPolicy` with bounded timeout, retry, and backoff.
- Apply policy to quote/search/history/HN upstream calls.
- Add in-memory TTL + stale-while-revalidate cache for:
  - `/api/hn/top`
  - `/api/stock/search`

### 3) Revision-safe state persistence (Issue #5)
- `/api/state` now enforces revision handshake:
  - `GET` returns `revision`
  - `POST` requires matching `revision`
  - conflict returns `409` with latest snapshot
- Frontend stores remote revision, handles `409` by deterministic merge + retry (no silent overwrite).

### 4) KDJ-native alert rules (Issue #7)
- Add alert rule types:
  - `kdj_cross`
  - `kdj_zone`
- Extend form rendering, param normalization, rule descriptions, evaluator, and history rendering.
- Alert history now displays indicator source provenance.

### 5) Modularization + testability baseline (Issues #6, #8)
- Extract reusable modules:
  - `core/shared-utils.js`
  - `core/indicator-utils.js`
  - `core/state-merge.js`
  - `core/signal-policy.js`
- `app.js` and `analysis.js` now consume shared core utilities for duplicated logic paths.
- Add Node native tests + CI workflow.

## Validation
- `npm run check`
- `npm test`
- Local smoke:
  - `/api/state` revision conflict path (`409`) and success path (`200` + new revision)
  - `/api/hn/top?limit=3` response

## Linked Issues
Closes #2
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
